### PR TITLE
Put interface config defaults into SystemRegistry

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,10 @@ Setup your network connection by running:
 Nerves.Network.setup "wlan0", ssid: "my_accesspoint_name", key_mgmt: :"WPA-PSK", psk: "secret"
 ```
 
-If your WiFi network does not use a secret key, specify the `key_mgmt` to be `:NONE`.
-Currently, wireless configuration passes almost unaltered to [wpa_supplicant.ex](https://github.com/nerves-project/nerves_wpa_supplicant), so see that
-project for more configuration options.
+If your WiFi network does not use a secret key, specify the `key_mgmt` to be
+`:NONE`. Currently, wireless configuration passes almost unaltered to
+[wpa_supplicant.ex](https://github.com/nerves-project/nerves_wpa_supplicant), so
+see that project for more configuration options.
 
 # Wired Networking
 
@@ -84,19 +85,21 @@ Nerves.Network.setup "usb0", ipv4_address_method: :linklocal
 
 # Configuring Defaults
 
-`nerves_netowrk` has the ability of setting a default configuration by passing
-setting them in the application configuration. This can be helpful when using
-`nerves_network` with [bootloader](https://github.com/nerves-project/bootloader).
+`nerves_network` allows default network interface settings to be set using
+application configuration. This can be helpful when using `nerves_network` with
+[`bootloader`](https://github.com/nerves-project/bootloader).  
 
 Configuring `bootloader` to start `nerves_network`:
+
 ```elixir
 config :bootloader,
   init: [:nerves_network],
   app: :your_app
 ```
 
-The following example will pull wifi network information from the system
-environment variables and configure ethernet to use DHCP:
+The following example will pull WiFi network settings from the system
+environment variables and configure the interface's IP address using DHCP:  
+
 ```elixir
 key_mgmt = System.get_env("NERVES_NETWORK_KEY_MGMT") || "WPA-PSK"
 
@@ -113,8 +116,7 @@ config :nerves_network, :default,
 
 ## Limitations
 
-Currently, only IPv4 is supported, and IP addresses can only be assigned via
-DHCP. The library is incredibly verbose in its logging to help debug issues
-on new platforms in prep for a first release. This will change. The library
-is mostly interim in its structure. Please consider submitting PRs and helping
-make this work reliably across embedded devices.
+Currently, only IPv4 is supported. The library is incredibly verbose in its
+logging to help debug issues on new platforms in prep for a first release. This
+will change. The library is mostly interim in its structure. Please consider
+submitting PRs and helping make this work reliably across embedded devices.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,35 @@ Nerves.Network.setup "eth0", ipv4_address_method: :static,
 Nerves.Network.setup "usb0", ipv4_address_method: :linklocal
 ```
 
+# Configuring Defaults
+
+`nerves_netowrk` has the ability of setting a default configuration by passing
+setting them in the application configuration. This can be helpful when using
+`nerves_network` with [bootloader](https://github.com/nerves-project/bootloader).
+
+Configuring `bootloader` to start `nerves_network`:
+```elixir
+config :bootloader,
+  init: [:nerves_network],
+  app: :your_app
+```
+
+The following example will pull wifi network information from the system
+environment variables and configure ethernet to use DHCP:
+```elixir
+key_mgmt = System.get_env("NERVES_NETWORK_KEY_MGMT") || "WPA-PSK"
+
+config :nerves_network, :default,
+  wlan0: [
+    ssid: System.get_env("NERVES_NETWORK_SSID"),
+    psk: System.get_env("NERVES_NETWORK_PSK"),
+    key_mgmt: String.to_atom(key_mgmt)
+  ],
+  eth0: [
+    ipv4_address_method: :dhcp
+  ]
+```
+
 ## Limitations
 
 Currently, only IPv4 is supported, and IP addresses can only be assigned via

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
+key_mgmt = System.get_env("NERVES_NETWORK_KEY_MGMT") || "WPA-PSK"
+
 config :nerves_network, :default,
   wlan0: [
     ssid: System.get_env("NERVES_NETWORK_SSID"),

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,11 @@
 use Mix.Config
 
-config :system_registry, SystemRegistry.Processor.Config,
-  priorities: [
-    :debug,
-    :nerves_network
+config :nerves_network, :default,
+  wlan0: [
+    ssid: System.get_env("NERVES_NETWORK_SSID"),
+    psk: System.get_env("NERVES_NETWORK_PSK"),
+    key_mgmt: String.to_atom(key_mgmt)
+  ],
+  eth0: [
+    ipv4_address_method: :dhcp
   ]

--- a/lib/nerves_network/config.ex
+++ b/lib/nerves_network/config.ex
@@ -13,14 +13,14 @@ defmodule Nerves.Network.Config  do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
-  def put(iface, config) do
+  def put(iface, config, priority \\ @priority) do
     scope(iface)
-    |> SR.update(config, priority: @priority)
+    |> SR.update(config, priority: priority)
   end
 
-  def drop(iface) do
+  def drop(iface, priority \\ @priority) do
     scope(iface)
-    |> SR.delete(priority: @priority)
+    |> SR.delete(priority: priority)
   end
 
   def init([]) do
@@ -30,7 +30,7 @@ defmodule Nerves.Network.Config  do
     Enum.each(defaults, fn({iface, config}) ->
       iface
       |> to_string()
-      |> put(config)
+      |> put(config, :default)
     end)
     {:ok, %{}}
   end

--- a/lib/nerves_network/config.ex
+++ b/lib/nerves_network/config.ex
@@ -25,6 +25,13 @@ defmodule Nerves.Network.Config  do
 
   def init([]) do
     SR.register
+    defaults =
+      Application.get_env(:nerves_network, :default, [])
+    Enum.each(defaults, fn({iface, config}) ->
+      iface
+      |> to_string()
+      |> put(config)
+    end)
     {:ok, %{}}
   end
 


### PR DESCRIPTION
When starting `:nerves_network` during the `:init` phase of `Bootloader` it would be nice for the interface to be configured with some defaults. This allows the board to boot to a network connected state incase of a soft brick.

For Example. Set the default settings for the `wlan0' interface
```elixir
config :nerves_network, :default,
  wlan0: [
    ssid: System.get_env("NERVES_NETWORK_SSID"),
    psk: System.get_env("NERVES_NETWORK_PSK"),
    key_mgmt: String.to_atom(key_mgmt)
  ]
```