### PR TITLE
Add catch-all handler for consume/3 in Nerves.Network.DHCPManager.

### DIFF
--- a/lib/nerves_network/dhcp_manager.ex
+++ b/lib/nerves_network/dhcp_manager.ex
@@ -207,6 +207,12 @@ defmodule Nerves.Network.DHCPManager do
   end
   defp consume(:up, {:leasefail, _info}, state), do: state
 
+  # Catch-all handler for consume
+  defp consume(context, event, state) do
+    Logger.warn "Unhandled event #{event} for context #{context} in consume/3."
+    state
+  end
+
   defp stop_udhcpc(state) do
     if is_pid(state.dhcp_pid) do
       Nerves.Network.Udhcpc.stop(state.dhcp_pid)


### PR DESCRIPTION
Otherwise, it crashes.  Instead of doing that, I propose we add a catch-all handler that warns when something isn't handled.