### PR TITLE
Add details about calling config within a process

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ If your WiFi network does not use a secret key, specify the `key_mgmt` to be
 [wpa_supplicant.ex](https://github.com/nerves-project/nerves_wpa_supplicant), so
 see that project for more configuration options.
 
+Note: If you call `Nerves.Network.setup` from within your application, place it
+in the main application `start` or another process with the same lifecycle as
+your application. If you call `setup` inside a Task or other process that exits,
+the configuration will be removed from the `SystemRegistry` and the interface
+will no longer be managed by `Nerves.Network`.
+
 # Wired Networking
 
 Wired networking setup varies in how IP addresses are expected to be assigned.


### PR DESCRIPTION
This change adds a note about calling Nerves.Networking.setup from inside the application.

I was using an old pattern of putting init_network in a transient Task and calling `setup` from within that function. I learned that doing that will cause the underlying configuration of the interface to be removed when the Task pid exits, so I want to make sure that others who might encounter this have an idea what is happening.