### PR TITLE
Poll network status from SystemRegistry

### DIFF
--- a/lib/nerves_network.ex
+++ b/lib/nerves_network.ex
@@ -46,10 +46,12 @@ defmodule Nerves.Network do
   end
 
   @doc """
-  Return a map with the current configuration and interface status.
+  Convenience function for returning the current status of a network interface
+  from SystemRegistry.
   """
   def status(ifname) do
-    Nerves.Network.IFSupervisor.status ifname
+    SystemRegistry.match(:_)
+    |> get_in([:state, :network_interface, ifname])
   end
 
   @doc """

--- a/lib/nerves_network/if_supervisor.ex
+++ b/lib/nerves_network/if_supervisor.ex
@@ -46,15 +46,6 @@ defmodule Nerves.Network.IFSupervisor do
      end
   end
 
-  def status(ifname) do
-     pidname = pname(ifname)
-     if Process.whereis(pidname) do
-       Nerves.NetworkInterface.status(ifname)
-     else
-       {:error, :not_started}
-     end
-  end
-
   defp pname(ifname) do
     String.to_atom("Nerves.Network.Interface." <> ifname)
   end


### PR DESCRIPTION
This fixes an issue where you'd only get back a subset of the interface
state when calling Nerves.Network.status/1 and most importantly it
now tells you the IP address.

This also removes the direct status call to Nerves.Network.Interface,
since it would be good to remove that eventually.

This fixes #18.