### PR TITLE
Default ipv4_address_method to DHCP

### DIFF
--- a/lib/nerves_network/if_supervisor.ex
+++ b/lib/nerves_network/if_supervisor.ex
@@ -57,6 +57,9 @@ defmodule Nerves.Network.IFSupervisor do
       :static -> Nerves.Network.StaticManager
       :linklocal -> Nerves.Network.LinkLocalManager
       :dhcp -> Nerves.Network.DHCPManager
+
+      # Default to DHCP if unset; crash if anything else.
+      nil -> Nerves.Network.DHCPManager
     end
   end
   defp manager(:wireless, _settings) do


### PR DESCRIPTION
It is really easy to forget to specify this and DHCP seems like a
reasonable default. This still crashes on unknown atoms.  I still
like that behavior to avoid situations where things like `:lnklocal`
are typoed and the system does something unexpected.