### PR TITLE
Change `term` typespec to `any`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ end
 
 # WiFi Networking
 
-## Installation & Setup
+## Installation and Setup
 
 You'll first need to set the regulatory domain in your `config.exs` to your ISO
 3166-1 alpha-2 country code. In theory this is optional, but you'll get the

--- a/lib/nerves_network.ex
+++ b/lib/nerves_network.ex
@@ -78,7 +78,7 @@ defmodule Nerves.Network do
   @doc """
   If `ifname` is a wireless LAN, scan for access points.
   """
-  @spec scan(Types.ifname) :: [String.t] | {:error, term()}
+  @spec scan(Types.ifname) :: [String.t] | {:error, any}
   def scan(ifname) do
     Nerves.Network.IFSupervisor.scan ifname
   end

--- a/lib/nerves_network.ex
+++ b/lib/nerves_network.ex
@@ -4,7 +4,7 @@ defmodule Nerves.Network do
 
   @moduledoc """
   The Nerves.Network application handles the low level details of connecting
-  to WiFi networks. To quickly get started, create a new Nerves project and add
+  to networks. To quickly get started, create a new Nerves project and add
   the following line someplace early on in your program:
 
       Nerves.Network.setup "wlan0", ssid: "myssid", key_mgmt: :"WPA-PSK", psk: "secretsecret"
@@ -78,7 +78,7 @@ defmodule Nerves.Network do
   @doc """
   If `ifname` is a wireless LAN, scan for access points.
   """
-  @spec scan(Types.ifname) :: [String.t]
+  @spec scan(Types.ifname) :: [String.t] | {:error, term()}
   def scan(ifname) do
     Nerves.Network.IFSupervisor.scan ifname
   end
@@ -86,7 +86,7 @@ defmodule Nerves.Network do
   @doc """
   Change the regulatory domain for wireless operations. This must be set to the
   two character `alpha2` code for the country where this device is operating.
-  See http://git.kernel.org/cgit/linux/kernel/git/sforshee/wireless-regdb.git/tree/db.txt
+  See [the kernel database](http://git.kernel.org/cgit/linux/kernel/git/sforshee/wireless-regdb.git/tree/db.txt)
   for the latest database and the frequencies allowed per country.
 
   The default is to use the world regulatory domain (00).

--- a/lib/nerves_network/config.ex
+++ b/lib/nerves_network/config.ex
@@ -1,4 +1,6 @@
 defmodule Nerves.Network.Config  do
+  @moduledoc false
+
   use GenServer
 
   require Logger

--- a/lib/nerves_network/config.ex
+++ b/lib/nerves_network/config.ex
@@ -6,7 +6,7 @@ defmodule Nerves.Network.Config  do
   require Logger
 
   alias SystemRegistry, as: SR
-  alias Nerves.Network.IFSupervisor
+  alias Nerves.Network.{IFSupervisor, Types}
 
   @scope [:config, :network_interface]
   @priority :nerves_network
@@ -15,9 +15,10 @@ defmodule Nerves.Network.Config  do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
+  @spec put(Types.ifname, Nerves.Network.setup_settings, atom) :: {:ok, {old :: map, new ::map}}
   def put(iface, config, priority \\ @priority) do
     scope(iface)
-    |> SR.update(config, priority: priority)
+    |> SR.update(config, [priority: priority])
   end
 
   def drop(iface, priority \\ @priority) do
@@ -64,6 +65,7 @@ defmodule Nerves.Network.Config  do
     new
   end
 
+  @spec scope(Types.ifname, append :: SR.scope) :: SR.scope
   defp scope(iface, append \\ []) do
     @scope ++ [iface | append]
   end

--- a/lib/nerves_network/dhcp_manager.ex
+++ b/lib/nerves_network/dhcp_manager.ex
@@ -13,11 +13,10 @@ defmodule Nerves.Network.DHCPManager do
             dhcp_retry_interval: 60_000,
             dhcp_retry_timer: nil
 
-  @typedoc "Atom for the context state machine."
-  @type context :: :removed | :removed | :retry_add | :down | :dhcp | :up
-
   @typedoc "Settings for starting the server."
   @type dhcp_settings :: Nerves.Network.setup_settings
+
+  @typep context :: Types.interface_context
 
   @typedoc """
   The current state machine state is called "context" to avoid confusion between server
@@ -58,10 +57,7 @@ defmodule Nerves.Network.DHCPManager do
     {:ok, state}
   end
 
-  @typedoc "Event from Nerves.NetworkInterface"
-  @type ifevent :: :ifadded | :ifremoved | :ifmoved | :ifup | :ifdown | :noop
-
-  @spec handle_network_interface_event({Nerves.NetworkInterface, ifevent, %{ifname: Types.ifname}}) :: ifevent
+  @spec handle_network_interface_event({Nerves.NetworkInterface, Types.ifevent, %{ifname: Types.ifname}}) :: Types.ifevent
   defp handle_network_interface_event({Nerves.NetworkInterface, :ifadded, %{ifname: ifname}}) do
     Logger.debug "DHCPManager(#{ifname}) network_interface ifadded"
     :ifadded
@@ -134,7 +130,7 @@ defmodule Nerves.Network.DHCPManager do
   end
 
   @typedoc "Event for the state machine."
-  @type event :: ifevent | Nerves.Network.Udhcpc.event
+  @type event :: Types.ifevent | Nerves.Network.Udhcpc.event
 
   @spec consume(context, event, t) :: t
   defp consume(_, :noop, state), do: state

--- a/lib/nerves_network/dhcp_manager.ex
+++ b/lib/nerves_network/dhcp_manager.ex
@@ -57,8 +57,8 @@ defmodule Nerves.Network.DHCPManager do
     {:ok, state}
   end
 
-  @spec handle_network_interface_event({Nerves.NetworkInterface, Types.ifevent, %{ifname: Types.ifname}}) :: Types.ifevent
-  defp handle_network_interface_event({Nerves.NetworkInterface, :ifadded, %{ifname: ifname}}) do
+  @spec handle_registry_event({Nerves.NetworkInterface, atom, %{ifname: Types.ifname}}) :: Types.ifevent
+  defp handle_registry_event({Nerves.NetworkInterface, :ifadded, %{ifname: ifname}}) do
     Logger.debug "DHCPManager(#{ifname}) network_interface ifadded"
     :ifadded
   end
@@ -66,12 +66,12 @@ defmodule Nerves.Network.DHCPManager do
   # :ifmoved occurs on systems that assign stable names to removable
   # interfaces. I.e. the interface is added under the dynamically chosen
   # name and then quickly renamed to something that is stable across boots.
-  defp handle_network_interface_event({Nerves.NetworkInterface, :ifmoved, %{ifname: ifname}}) do
+  defp handle_registry_event({Nerves.NetworkInterface, :ifmoved, %{ifname: ifname}}) do
     Logger.debug "DHCPManager(#{ifname}) network_interface ifadded (moved)"
     :ifadded
   end
 
-  defp handle_network_interface_event({Nerves.NetworkInterface, :ifremoved, %{ifname: ifname}}) do
+  defp handle_registry_event({Nerves.NetworkInterface, :ifremoved, %{ifname: ifname}}) do
     Logger.debug "DHCPManager(#{ifname}) network_interface ifremoved"
     :ifremoved
   end
@@ -79,24 +79,24 @@ defmodule Nerves.Network.DHCPManager do
   # Filter out ifup and ifdown events
   # :is_up reports whether the interface is enabled or disabled (like by the wifi kill switch)
   # :is_lower_up reports whether the interface as associated with an AP
-  defp handle_network_interface_event({Nerves.NetworkInterface, :ifchanged, %{ifname: ifname, is_lower_up: true}}) do
+  defp handle_registry_event({Nerves.NetworkInterface, :ifchanged, %{ifname: ifname, is_lower_up: true}}) do
     Logger.debug "DHCPManager(#{ifname}) network_interface ifup"
     :ifup
   end
 
-  defp handle_network_interface_event({Nerves.NetworkInterface, :ifchanged, %{ifname: ifname, is_lower_up: false}}) do
+  defp handle_registry_event({Nerves.NetworkInterface, :ifchanged, %{ifname: ifname, is_lower_up: false}}) do
     Logger.debug "DHCPManager(#{ifname}) network_interface ifdown"
     :ifdown
   end
 
-  defp handle_network_interface_event({Nerves.NetworkInterface, event, %{ifname: ifname}}) do
+  defp handle_registry_event({Nerves.NetworkInterface, event, %{ifname: ifname}}) do
     Logger.debug "DHCPManager(#{ifname}): ignoring event: #{inspect event}"
     :noop
   end
 
   # Handle Network Interface events coming in from SystemRegistry.
   def handle_info({Nerves.NetworkInterface, _, ifstate} = event, %{ifname: ifname} = s) do
-    event = handle_network_interface_event(event)
+    event = handle_registry_event(event)
     scope(ifname) |> SystemRegistry.update(ifstate)
     s = consume(s.context, event, s)
     Logger.debug "DHCPManager(#{s.ifname}, #{s.context}) got event #{inspect event}"

--- a/lib/nerves_network/if_supervisor.ex
+++ b/lib/nerves_network/if_supervisor.ex
@@ -51,7 +51,7 @@ defmodule Nerves.Network.IFSupervisor do
      end
   end
 
-  @spec pname(Types.ifname) :: String.t
+  @spec pname(Types.ifname) :: atom
   defp pname(ifname) do
     String.to_atom("Nerves.Network.Interface." <> ifname)
   end

--- a/lib/nerves_network/if_supervisor.ex
+++ b/lib/nerves_network/if_supervisor.ex
@@ -41,7 +41,7 @@ defmodule Nerves.Network.IFSupervisor do
     end
   end
 
-  @spec scan(Types.ifname) :: [String.t] | {:error, term()}
+  @spec scan(Types.ifname) :: [String.t] | {:error, any}
   def scan(ifname) do
      pidname = pname(ifname)
      if Process.whereis(pidname) do

--- a/lib/nerves_network/linklocal_manager.ex
+++ b/lib/nerves_network/linklocal_manager.ex
@@ -99,35 +99,18 @@ defmodule Nerves.Network.LinkLocalManager do
 
   @spec consume(context, event, t) :: t
   defp consume(_, :noop, state), do: state
+
   ## Context: :removed
   defp consume(:removed, :ifadded, state) do
-    case Nerves.NetworkInterface.ifup(state.ifname) do
-      :ok ->
-        {:ok, status} = Nerves.NetworkInterface.status(state.ifname)
-        notify(Nerves.NetworkInterface, state.ifname, :ifchanged, status)
-
-        goto_context(state, :down)
-      {:error, _} ->
-        # The interface isn't quite up yet. Retry
-        Process.send_after self(), :retry_ifadded, 250
-        goto_context(state, :retry_add)
-    end
-  end
-  defp consume(:removed, :retry_ifadded, state), do: state
-  defp consume(:removed, :ifdown, state), do: state
-  defp consume(:removed, :ifremoved, state), do: state
-
-  ## Context: :retry_add
-  defp consume(:retry_add, :ifadded, state), do: state
-  defp consume(:retry_add, :retry_ifadded, state) do
+    :ok = Nerves.NetworkInterface.ifup(state.ifname)
     {:ok, status} = Nerves.NetworkInterface.status(state.ifname)
     notify(Nerves.NetworkInterface, state.ifname, :ifchanged, status)
 
     goto_context(state, :down)
   end
-  defp consume(:retry_add, :ifremoved, state) do
-    goto_context(state, :removed)
-  end
+
+  defp consume(:removed, :ifdown, state), do: state
+  defp consume(:removed, :ifremoved, state), do: state
 
   ## Context: :down
   defp consume(:down, :ifadded, state), do: state
@@ -153,7 +136,7 @@ defmodule Nerves.Network.LinkLocalManager do
     {:ok, ifsettings} = Nerves.NetworkInterface.status(state.ifname)
     ip = generate_link_local(ifsettings.mac_address)
     scope(state.ifname)
-    |> SystemRegistry.update(%{ipv4_address: ip})
+      |> SystemRegistry.update(%{ipv4_address: ip})
     :ok = Nerves.NetworkInterface.setup(state.ifname, [ipv4_address: ip])
     state
   end

--- a/lib/nerves_network/linklocal_manager.ex
+++ b/lib/nerves_network/linklocal_manager.ex
@@ -42,19 +42,19 @@ defmodule Nerves.Network.LinkLocalManager do
     {:ok, state}
   end
 
-  @spec handle_network_interface_event({Nerves.NetworkInterface, Types.ifevent, %{ifname: Types.ifname}}) :: Types.ifevent
-  def handle_network_interface_event({Nerves.NetworkInterface, :ifadded, %{ifname: ifname}}) do
+  @spec handle_registry_event({Nerves.NetworkInterface, atom, %{ifname: Types.ifname, is_lower_up: boolean}}) :: Types.ifevent
+  defp handle_registry_event({Nerves.NetworkInterface, :ifadded, %{ifname: ifname}}) do
     Logger.debug "LinkLocalManager(#{ifname}) network_interface ifadded"
     :ifadded
   end
   # :ifmoved occurs on systems that assign stable names to removable
   # interfaces. I.e. the interface is added under the dynamically chosen
   # name and then quickly renamed to something that is stable across boots.
-  def handle_network_interface_event({Nerves.NetworkInterface, :ifmoved, %{ifname: ifname}}) do
+  defp handle_registry_event({Nerves.NetworkInterface, :ifmoved, %{ifname: ifname}}) do
     Logger.debug "LinkLocalManager(#{ifname}) network_interface ifadded (moved)"
     :ifadded
   end
-  def handle_network_interface_event({Nerves.NetworkInterface, :ifremoved, %{ifname: ifname}}) do
+  defp handle_registry_event({Nerves.NetworkInterface, :ifremoved, %{ifname: ifname}}) do
     Logger.debug "LinkLocalManager(#{ifname}) network_interface ifremoved"
     :ifremoved
   end
@@ -62,22 +62,22 @@ defmodule Nerves.Network.LinkLocalManager do
   # Filter out ifup and ifdown events
   # :is_up reports whether the interface is enabled or disabled (like by the wifi kill switch)
   # :is_lower_up reports whether the interface as associated with an AP
-  def handle_network_interface_event({Nerves.NetworkInterface, :ifchanged, %{ifname: ifname, is_lower_up: true}}) do
+  defp handle_registry_event({Nerves.NetworkInterface, :ifchanged, %{ifname: ifname, is_lower_up: true}}) do
     Logger.debug "LinkLocalManager(#{ifname}) network_interface ifup"
     :ifup
   end
-  def handle_network_interface_event({Nerves.NetworkInterface, :ifchanged, %{ifname: ifname, is_lower_up: false}}) do
+  defp handle_registry_event({Nerves.NetworkInterface, :ifchanged, %{ifname: ifname, is_lower_up: false}}) do
     Logger.debug "LinkLocalManager(#{ifname}) network_interface ifdown"
     :ifdown
   end
 
-  def handle_network_interface_event({Nerves.NetworkInterface, event, %{ifname: ifname}}) do
+  defp handle_registry_event({Nerves.NetworkInterface, event, %{ifname: ifname}}) do
     Logger.debug "LinkLocalManager(#{ifname}): ignoring event: #{inspect event}"
     :noop
   end
 
   def handle_info({Nerves.NetworkInterface, _, ifstate} = event, %{ifname: ifname} = s) do
-    event = handle_network_interface_event(event)
+    event = handle_registry_event(event)
     scope(ifname) |> SystemRegistry.update(ifstate)
     s = consume(s.context, event, s)
     Logger.debug "LinkLocalManager(#{s.ifname}, #{s.context}) got event #{inspect event}"

--- a/lib/nerves_network/linklocal_manager.ex
+++ b/lib/nerves_network/linklocal_manager.ex
@@ -2,15 +2,24 @@ defmodule Nerves.Network.LinkLocalManager do
   use GenServer
   require Logger
   import Nerves.Network.Utils
+  alias Nerves.Network.Types
 
   @moduledoc false
 
-  # The current state machine state is called "context" to avoid confusion between server
-  # state and state machine state.
   defstruct context: :removed,
             ifname: nil,
             settings: nil
 
+  @typep context :: Types.interface_context
+
+  @type t :: %__MODULE__{
+    context: context,
+    ifname: Types.ifname | nil,
+    settings: Nerves.Network.setup_settings | nil
+  }
+
+  @doc false
+  @spec start_link(Types.ifname, Nerves.Network.setup_settings, GenServer.options) :: GenServer.on_start
   def start_link(ifname, settings, opts \\ []) do
     GenServer.start_link(__MODULE__, {ifname, settings}, opts)
   end
@@ -33,41 +42,42 @@ defmodule Nerves.Network.LinkLocalManager do
     {:ok, state}
   end
 
-  def handle_event({Nerves.NetworkInterface, :ifadded, %{ifname: ifname}}) do
-    Logger.debug "LinkLocalManager.EventHandler(#{ifname}) ifadded"
+  @spec handle_network_interface_event({Nerves.NetworkInterface, Types.ifevent, %{ifname: Types.ifname}}) :: Types.ifevent
+  def handle_network_interface_event({Nerves.NetworkInterface, :ifadded, %{ifname: ifname}}) do
+    Logger.debug "LinkLocalManager(#{ifname}) network_interface ifadded"
     :ifadded
   end
   # :ifmoved occurs on systems that assign stable names to removable
   # interfaces. I.e. the interface is added under the dynamically chosen
   # name and then quickly renamed to something that is stable across boots.
-  def handle_event({Nerves.NetworkInterface, :ifmoved, %{ifname: ifname}}) do
-    Logger.debug "LinkLocalManager.EventHandler(#{ifname}) ifadded (moved)"
+  def handle_network_interface_event({Nerves.NetworkInterface, :ifmoved, %{ifname: ifname}}) do
+    Logger.debug "LinkLocalManager(#{ifname}) network_interface ifadded (moved)"
     :ifadded
   end
-  def handle_event({Nerves.NetworkInterface, :ifremoved, %{ifname: ifname}}) do
-    Logger.debug "LinkLocalManager.EventHandler(#{ifname}) ifremoved"
+  def handle_network_interface_event({Nerves.NetworkInterface, :ifremoved, %{ifname: ifname}}) do
+    Logger.debug "LinkLocalManager(#{ifname}) network_interface ifremoved"
     :ifremoved
   end
 
   # Filter out ifup and ifdown events
   # :is_up reports whether the interface is enabled or disabled (like by the wifi kill switch)
   # :is_lower_up reports whether the interface as associated with an AP
-  def handle_event({Nerves.NetworkInterface, :ifchanged, %{ifname: ifname, is_lower_up: true}}) do
-    Logger.debug "LinkLocalManager.EventHandler(#{ifname}) ifup"
+  def handle_network_interface_event({Nerves.NetworkInterface, :ifchanged, %{ifname: ifname, is_lower_up: true}}) do
+    Logger.debug "LinkLocalManager(#{ifname}) network_interface ifup"
     :ifup
   end
-  def handle_event({Nerves.NetworkInterface, :ifchanged, %{ifname: ifname, is_lower_up: false}}) do
-    Logger.debug "LinkLocalManager.EventHandler(#{ifname}) ifdown"
+  def handle_network_interface_event({Nerves.NetworkInterface, :ifchanged, %{ifname: ifname, is_lower_up: false}}) do
+    Logger.debug "LinkLocalManager(#{ifname}) network_interface ifdown"
     :ifdown
   end
 
-  def handle_event({Nerves.NetworkInterface, event, %{ifname: ifname}}) do
-    Logger.debug "LinkLocalManager.EventHandler(#{ifname}): ignoring event: #{inspect event}"
+  def handle_network_interface_event({Nerves.NetworkInterface, event, %{ifname: ifname}}) do
+    Logger.debug "LinkLocalManager(#{ifname}): ignoring event: #{inspect event}"
     :noop
   end
 
   def handle_info({Nerves.NetworkInterface, _, ifstate} = event, %{ifname: ifname} = s) do
-    event = handle_event(event)
+    event = handle_network_interface_event(event)
     scope(ifname) |> SystemRegistry.update(ifstate)
     s = consume(s.context, event, s)
     Logger.debug "LinkLocalManager(#{s.ifname}, #{s.context}) got event #{inspect event}"
@@ -75,15 +85,19 @@ defmodule Nerves.Network.LinkLocalManager do
   end
 
   def handle_info(event, s) do
-    Logger.debug "LinkLocalManager.EventHandler(#{s.ifname}): ignoring event: #{inspect event}"
+    Logger.debug "LinkLocalManager(#{s.ifname}): ignoring event: #{inspect event}"
     {:noreply, s}
   end
 
+  @type event :: Types.ifevent
+
   ## State machine implementation
+  @spec goto_context(t, context) :: t
   defp goto_context(state, newcontext) do
     %Nerves.Network.LinkLocalManager{state | context: newcontext}
   end
 
+  @spec consume(context, event, t) :: t
   defp consume(_, :noop, state), do: state
   ## Context: :removed
   defp consume(:removed, :ifadded, state) do
@@ -134,6 +148,7 @@ defmodule Nerves.Network.LinkLocalManager do
     goto_context(state, :down)
   end
 
+  @spec start_link_local(t) :: t
   defp start_link_local(state) do
     {:ok, ifsettings} = Nerves.NetworkInterface.status(state.ifname)
     ip = generate_link_local(ifsettings.mac_address)

--- a/lib/nerves_network/resolvconf.ex
+++ b/lib/nerves_network/resolvconf.ex
@@ -142,7 +142,7 @@ defmodule Nerves.Network.Resolvconf do
   end
   defp nameserver_text(_), do: ""
 
-  @spec write_resolvconf(%{filename: Path.t}) :: :ok
+  @spec write_resolvconf(%{filename: Path.t, ifmap: ifmap | map}) :: :ok
   defp write_resolvconf(state) do
     domains = Enum.map(state.ifmap, &domain_text/1)
     nameservers = Enum.map(state.ifmap, &nameserver_text/1)

--- a/lib/nerves_network/resolvconf.ex
+++ b/lib/nerves_network/resolvconf.ex
@@ -47,7 +47,7 @@ defmodule Nerves.Network.Resolvconf do
 
     %{domain: "example.com", nameservers: ["8.8.8.8", "8.8.4.4"]}
   """
-  @spec setup(resolvconf, Types.ifname, Nerves.Network.setup_settings | ifmap) :: :ok
+  @spec setup(resolvconf, Types.ifname, Nerves.Network.setup_settings | Types.udhcp_info) :: :ok
   def setup(resolv_conf, ifname, options) when is_list(options) do
     setup(resolv_conf, ifname, :maps.from_list(options))
   end
@@ -142,7 +142,7 @@ defmodule Nerves.Network.Resolvconf do
   end
   defp nameserver_text(_), do: ""
 
-  @spec write_resolvconf(state) :: :ok | no_return
+  @spec write_resolvconf(%{filename: Path.t}) :: :ok
   defp write_resolvconf(state) do
     domains = Enum.map(state.ifmap, &domain_text/1)
     nameservers = Enum.map(state.ifmap, &nameserver_text/1)

--- a/lib/nerves_network/static_manager.ex
+++ b/lib/nerves_network/static_manager.ex
@@ -1,5 +1,5 @@
 defmodule Nerves.Network.StaticManager do
-  @moduledoc "Handles static ip address settings."
+  @moduledoc false
 
   use GenServer
   import Nerves.Network.Utils

--- a/lib/nerves_network/static_manager.ex
+++ b/lib/nerves_network/static_manager.ex
@@ -1,4 +1,6 @@
 defmodule Nerves.Network.StaticManager do
+  @moduledoc "Handles static ip address settings."
+
   use GenServer
   import Nerves.Network.Utils
   require Logger

--- a/lib/nerves_network/types.ex
+++ b/lib/nerves_network/types.ex
@@ -12,5 +12,7 @@ defmodule Nerves.Network.Types do
   @type ifevent :: :ifadded | :ifremoved | :ifmoved | :ifup | :ifdown | :noop | :retry_ifadded
 
   @typedoc "Atom for the context state machine."
-  @type interface_context :: :removed | :removed | :retry_add | :down | :up
+  @type interface_context :: :removed | :retry_add | :down | :up
+
+  @type udhcp_info :: %{ifname: ifname, nameservers: [ip_address], domain: String.t}
 end

--- a/lib/nerves_network/types.ex
+++ b/lib/nerves_network/types.ex
@@ -9,8 +9,8 @@ defmodule Nerves.Network.Types do
 
   # Please move this innto Nerves.NetworkInterface.
   @typedoc "Event from Nerves.NetworkInterface"
-  @type ifevent :: :ifadded | :ifremoved | :ifmoved | :ifup | :ifdown | :noop
+  @type ifevent :: :ifadded | :ifremoved | :ifmoved | :ifup | :ifdown | :noop | :retry_ifadded
 
   @typedoc "Atom for the context state machine."
-  @type interface_context :: :removed | :removed | :retry_add | :down | :dhcp | :up
+  @type interface_context :: :removed | :removed | :retry_add | :down | :up
 end

--- a/lib/nerves_network/types.ex
+++ b/lib/nerves_network/types.ex
@@ -6,4 +6,11 @@ defmodule Nerves.Network.Types do
 
   @typedoc "Interface name string."
   @type ifname :: String.t
+
+  # Please move this innto Nerves.NetworkInterface.
+  @typedoc "Event from Nerves.NetworkInterface"
+  @type ifevent :: :ifadded | :ifremoved | :ifmoved | :ifup | :ifdown | :noop
+
+  @typedoc "Atom for the context state machine."
+  @type interface_context :: :removed | :removed | :retry_add | :down | :dhcp | :up
 end

--- a/lib/nerves_network/types.ex
+++ b/lib/nerves_network/types.ex
@@ -1,0 +1,9 @@
+defmodule Nerves.Network.Types do
+  @moduledoc "Types for interacting with Network."
+
+  @typedoc "Ipaddress string."
+  @type ip_address :: String.t
+
+  @typedoc "Interface name string."
+  @type ifname :: String.t
+end

--- a/lib/nerves_network/udhcpc.ex
+++ b/lib/nerves_network/udhcpc.ex
@@ -107,7 +107,7 @@ defmodule Nerves.Network.Udhcpc do
   @typedoc "Event from the udhcpc server to be sent via SystemRegistry."
   @type event :: :deconfig | :bound | :renew | :leasefail | :nak
 
-  @spec handle_udhcpc(udhcpc_wrapper_event, state) :: state
+  @spec handle_udhcpc(udhcpc_wrapper_event, state) :: {:noreply, state}
   defp handle_udhcpc(["deconfig", ifname | _rest], state) do
     Logger.debug "udhcpc: deconfigure #{ifname}"
 

--- a/lib/nerves_network/udhcpc.ex
+++ b/lib/nerves_network/udhcpc.ex
@@ -17,6 +17,9 @@ defmodule Nerves.Network.Udhcpc do
   require Logger
   alias Nerves.Network.Utils
 
+  @typedoc "Event from the udhcpc wrapper."
+  @type event :: term() #FIXME
+
   @moduledoc """
   This module interacts with `udhcpc` to interact with DHCP servers.
   """

--- a/lib/nerves_network/udhcpc.ex
+++ b/lib/nerves_network/udhcpc.ex
@@ -18,7 +18,7 @@ defmodule Nerves.Network.Udhcpc do
   alias Nerves.Network.{Types, Utils}
 
   @typedoc "Instance of this server."
-  @type udhpc :: GenServer.server
+  @type udhcpc :: GenServer.server
 
   @moduledoc """
   This module interacts with `udhcpc` to interact with DHCP servers.
@@ -107,7 +107,7 @@ defmodule Nerves.Network.Udhcpc do
   @typedoc "Event from the udhcpc server to be sent via SystemRegistry."
   @type event :: :deconfig | :bound | :renew | :leasefail | :nak
 
-  @spec handle_udhcpc(udhcpc_wrapper_event, Types.ifname, state) :: state
+  @spec handle_udhcpc(udhcpc_wrapper_event, state) :: state
   defp handle_udhcpc(["deconfig", ifname | _rest], state) do
     Logger.debug "udhcpc: deconfigure #{ifname}"
 

--- a/lib/nerves_network/udhcpc.ex
+++ b/lib/nerves_network/udhcpc.ex
@@ -15,10 +15,10 @@
 defmodule Nerves.Network.Udhcpc do
   use GenServer
   require Logger
-  alias Nerves.Network.Utils
+  alias Nerves.Network.{Types, Utils}
 
-  @typedoc "Event from the udhcpc wrapper."
-  @type event :: term() #FIXME
+  @typedoc "Instance of this server."
+  @type udhpc :: GenServer.server
 
   @moduledoc """
   This module interacts with `udhcpc` to interact with DHCP servers.
@@ -28,6 +28,7 @@ defmodule Nerves.Network.Udhcpc do
   Start and link a Udhcpc process for the specified interface (i.e., eth0,
   wlan0).
   """
+  @spec start_link(Types.ifname) :: GenServer.on_start()
   def start_link(ifname) do
     GenServer.start_link(__MODULE__, ifname)
   end
@@ -37,6 +38,7 @@ defmodule Nerves.Network.Udhcpc do
   this interface. After calling this, be sure to disassociate the IP address
   from the interface so that packets don't accidentally get sent or processed.
   """
+  @spec release(udhcpc) :: :ok
   def release(pid) do
     GenServer.call(pid, :release)
   end
@@ -44,6 +46,7 @@ defmodule Nerves.Network.Udhcpc do
   @doc """
   Renew the lease on the IP address with the DHCP server.
   """
+  @spec renew(udhcpc) :: :ok
   def renew(pid) do
     GenServer.call(pid, :renew)
   end
@@ -51,6 +54,7 @@ defmodule Nerves.Network.Udhcpc do
   @doc """
   Stop the dhcp client
   """
+  @spec stop(udhcpc) :: :ok
   def stop(pid) do
     GenServer.stop(pid)
   end
@@ -87,10 +91,6 @@ defmodule Nerves.Network.Udhcpc do
     {:reply, :ok, state}
   end
 
-  # def handle_cast(:stop, state) do
-  #   {:stop, :normal, state}
-  # end
-
   def handle_info({_, {:data, {:eol, message}}}, state) do
     message
       |> List.to_string
@@ -98,41 +98,55 @@ defmodule Nerves.Network.Udhcpc do
       |> handle_udhcpc(state)
   end
 
+  @typedoc "State of the GenServer."
+  @type state :: %{ifname: Types.ifname, port: port}
+
+  @typedoc "Message from the udhcpc port."
+  @type udhcpc_wrapper_event :: [...] # we can do better.
+
+  @typedoc "Event from the udhcpc server to be sent via SystemRegistry."
+  @type event :: :deconfig | :bound | :renew | :leasefail | :nak
+
+  @spec handle_udhcpc(udhcpc_wrapper_event, Types.ifname, state) :: state
   defp handle_udhcpc(["deconfig", ifname | _rest], state) do
     Logger.debug "udhcpc: deconfigure #{ifname}"
 
     Utils.notify(Nerves.Udhcpc, state.ifname, :deconfig, %{ifname: ifname})
     {:noreply, state}
   end
+
   defp handle_udhcpc(["bound", ifname, ip, broadcast, subnet, router, domain, dns, _message], state) do
     dnslist = String.split(dns, " ")
     Logger.debug "udhcpc: bound #{ifname}: IP=#{ip}, dns=#{inspect dns}"
     Utils.notify(Nerves.Udhcpc, state.ifname, :bound, %{ifname: ifname, ipv4_address: ip, ipv4_broadcast: broadcast, ipv4_subnet_mask: subnet, ipv4_gateway: router, domain: domain, nameservers: dnslist})
     {:noreply, state}
   end
+
   defp handle_udhcpc(["renew", ifname, ip, broadcast, subnet, router, domain, dns, _message], state) do
     dnslist = String.split(dns, " ")
     Logger.debug "udhcpc: renew #{ifname}"
     Utils.notify(Nerves.Udhcpc, state.ifname, :renew, %{ifname: ifname, ipv4_address: ip, ipv4_broadcast: broadcast, ipv4_subnet_mask: subnet, ipv4_gateway: router, domain: domain, nameservers: dnslist})
     {:noreply, state}
   end
+
   defp handle_udhcpc(["leasefail", ifname, _ip, _broadcast, _subnet, _router, _domain, _dns, message], state) do
     Logger.debug "udhcpc: #{ifname}: leasefail #{message}"
     Utils.notify(Nerves.Udhcpc, state.ifname, :leasefail, %{ifname: ifname, message: message})
     {:noreply, state}
   end
+
   defp handle_udhcpc(["nak", ifname, _ip, _broadcast, _subnet, _router, _domain, _dns, message], state) do
     Logger.debug "udhcpc: #{ifname}: NAK #{message}"
     Utils.notify(Nerves.Udhcpc, state.ifname, :nak, %{ifname: ifname, message: message})
     {:noreply, state}
   end
+
   defp handle_udhcpc(_something_else, state) do
-    #msg = List.foldl(something_else, "", &<>/2)
-    #Logger.debug "udhcpc: ignoring unhandled message: #{msg}"
     {:noreply, state}
   end
 
-  defp hostname() do
+  @spec hostname :: String.t
+  defp hostname do
     {:ok, hostname} = :inet.gethostname()
     to_string(hostname)
     |> String.trim

--- a/lib/nerves_network/utils.ex
+++ b/lib/nerves_network/utils.ex
@@ -1,4 +1,5 @@
 defmodule Nerves.Network.Utils do
+  @moduledoc false
   @scope [:state, :network_interface]
 
   def notify(registry, key, notif, data) do


### PR DESCRIPTION
`term` is a fine choice, but `any` communicates more intentionally.
I also believe that it is more clear for people less familiar with the
typespec system.

Amos King @adkron <amos@binarynoggin.com>