### PR TITLE
None no psk

### DIFF
--- a/lib/nerves_network/wifi_manager.ex
+++ b/lib/nerves_network/wifi_manager.ex
@@ -269,7 +269,7 @@ defmodule Nerves.Network.WiFiManager do
     {:ok, pid} = Nerves.WpaSupplicant.start_link(state.ifname, wpa_control_pipe, name: :"Nerves.WpaSupplicant.#{state.ifname}")
     Logger.info "Register Nerves.WpaSupplicant #{inspect state.ifname}"
     {:ok, _} = Registry.register(Nerves.WpaSupplicant, state.ifname, [])
-    wpa_supplicant_settings = Map.new(state.settings)
+    wpa_supplicant_settings = parse_settings(state.settings)
     case Nerves.WpaSupplicant.set_network(pid, wpa_supplicant_settings) do
       :ok -> :ok
       error ->
@@ -279,6 +279,19 @@ defmodule Nerves.Network.WiFiManager do
 
     %Nerves.Network.WiFiManager{state | wpa_pid: pid}
   end
+
+  defp parse_settings(settings) when is_list(settings) do
+    settings
+    |> Map.new
+    |> parse_settings
+  end
+
+  defp parse_settings(settings = %{ key_mgmt: key_mgmt }) when is_binary(key_mgmt) do
+    %{ settings | key_mgmt: String.to_atom(key_mgmt) }
+    |> parse_settings
+  end
+
+  defp parse_settings(settings), do: settings
 
   defp stop_udhcpc(state) do
     if is_pid(state.dhcp_pid) do

--- a/lib/nerves_network/wifi_manager.ex
+++ b/lib/nerves_network/wifi_manager.ex
@@ -291,6 +291,11 @@ defmodule Nerves.Network.WiFiManager do
     |> parse_settings
   end
 
+  defp parse_settings(settings = %{ key_mgmt: :NONE, psk: _psk }) do
+    Map.delete(settings, :psk)
+    |> parse_settings
+  end
+
   defp parse_settings(settings), do: settings
 
   defp stop_udhcpc(state) do


### PR DESCRIPTION
   Building on my PR #38, this removes :psk from the settings passed
    to WpaSupplicant if using no encryption, thus avoiding the error
    as described in #39.