### PR TITLE
Fix reporting of unhandled DHCP events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.3.5-dev
 
+  * Enhancements
+    * Fix reporting of unhandled DHCP events.
+
 ## v0.3.4
 
   * Enhancements

--- a/lib/nerves_network/dhcp_manager.ex
+++ b/lib/nerves_network/dhcp_manager.ex
@@ -193,7 +193,7 @@ defmodule Nerves.Network.DHCPManager do
 
   # Catch-all handler for consume
   defp consume(context, event, state) do
-    Logger.warn "Unhandled event #{event} for context #{context} in consume/3."
+    Logger.warn "Unhandled event #{event} for context #{inspect context} in consume/3."
     state
   end
 


### PR DESCRIPTION
I believe `inspect` is missed here.