### PR TITLE
Clarify that `Nerves.Network.teardown/1` does not do defaults

### DIFF
--- a/lib/nerves_network.ex
+++ b/lib/nerves_network.ex
@@ -56,7 +56,23 @@ defmodule Nerves.Network do
   end
 
   @doc """
-  Stop all control of `ifname`
+  Stop all control of non-default `ifname`
+
+  Any interface that is configured under `:default` cannot be torn down.
+
+  For example:
+
+  ## Config
+~~~
+  config :nerves_network, :default,
+    eth0: [
+      ipv4_address_method: :dhcp
+    ]
+~~~
+
+  ## Does Nothing
+
+  > Nerves.Network teardown("eth0")
   """
   @spec teardown(Types.ifname) :: :ok
   def teardown(ifname) do

--- a/test/nerves_interim_wifi_test.exs
+++ b/test/nerves_interim_wifi_test.exs
@@ -1,8 +1,0 @@
-defmodule Nerves.NetworkTest do
-  use ExUnit.Case
-  doctest Nerves.Network
-
-  test "the truth" do
-    assert 1 + 1 == 2
-  end
-end

--- a/test/nerves_network_test.exs
+++ b/test/nerves_network_test.exs
@@ -1,0 +1,19 @@
+defmodule Nerves.NetworkTest do
+  use ExUnit.Case, async: false
+  doctest Nerves.Network
+
+  test "default network interface is not removed when we teardown" do
+    assert Map.has_key?(:sys.get_state(process.whereis(Nerves.Network.Config)), "eth0")
+
+    Nerves.Network.teardown("eth0")
+    assert Map.has_key?(:sys.get_state(process.whereis(Nerves.Network.Config)), "eth0")
+  end
+
+  test "non-default network interface is removed when we teardown" do
+    Nerves.Network.setup("non-default")
+    assert Map.has_key?(:sys.get_state(process.whereis(Nerves.Network.Config)), "non-default")
+
+    Nerves.Network.teardown("non-default")
+    refute Map.has_key?(:sys.get_state(process.whereis(Nerves.Network.Config)), "non-default")
+  end
+end


### PR DESCRIPTION
Any interfaces configured as a default will not be torn down by the
teardown function. This isn't readily clear to the user so a little
documentation is the next step. We can change this behaviour, but I
thought current documentation was the best first step.

Amos King @adkron <amos@binarynoggin.com>