### PR TITLE
Add inspect to event in consume/3 warning for unhandled events.

### DIFF
--- a/lib/nerves_network/dhcp_manager.ex
+++ b/lib/nerves_network/dhcp_manager.ex
@@ -193,7 +193,7 @@ defmodule Nerves.Network.DHCPManager do
 
   # Catch-all handler for consume
   defp consume(context, event, state) do
-    Logger.warn "Unhandled event #{event} for context #{inspect context} in consume/3."
+    Logger.warn "Unhandled event #{inspect event} for context #{inspect context} in consume/3."
     state
   end
 


### PR DESCRIPTION
The `event` parameter also needs to be rendered with `inspect`.  