### PR TITLE
Handle renew event inside dhcp manager

### DIFF
--- a/lib/nerves_network/dhcp_manager.ex
+++ b/lib/nerves_network/dhcp_manager.ex
@@ -231,6 +231,15 @@ defmodule Nerves.Network.DHCPManager do
       |> goto_context(:down)
   end
 
+  defp consume(:up, {:renew, info}, state) do
+    state
+    |> configure(info)
+
+    {:ok, status} = Nerves.NetworkInterface.status(state.ifname)
+    notify(Nerves.NetworkInterface, state.ifname, :ifchanged, status)
+    state
+  end
+
   # Catch-all handler for consume
   defp consume(context, event, state) do
     Logger.warn "Unhandled event #{inspect event} for context #{inspect context} in consume/3."


### PR DESCRIPTION
Originally the renw event was un-handled. When I started looking I
thought this was okay because it seemed like an informational event.
After looking further there is a possibility that the ip or other info
could change on a renew. Since that is the case we need to update our
configuration based on the information coming in. I thought of checking
and only notifying if the state actually changed, but that
would take more time than it would save since this shouldn't be a
frequent message.

Amos King @adkron <amos@binarynoggin.com>