### PR TITLE
Allow to configure the IPv4 method on wireless interfaces

### DIFF
--- a/lib/nerves_network/wifi_manager.ex
+++ b/lib/nerves_network/wifi_manager.ex
@@ -354,6 +354,7 @@ defmodule Nerves.Network.WiFiManager do
   defp parse_settings(settings) when is_list(settings) do
     settings
     |> Map.new
+    |> Map.take([:ssid, :key_mgmt, :psk])
     |> parse_settings
   end
 


### PR DESCRIPTION
It was not possible to use wireless interfaces with a static IP. This pull request aims to change this behaviour by enabling IP configuration like on wired interfaces.

This is enssentially an old commit from @ConnorRigby which had not been merged, plus a patch to filter configuration values passed to `wpa_supplicant` in order to avoid it to fail. It works as is, but IMO we should filter the parameters in `nerves_wpa_supplicant` in the future. This would be more appropriate and robust in term of design.