### PR TITLE
Allow configs to be changed at runtime.

### DIFF
--- a/lib/nerves_network/config.ex
+++ b/lib/nerves_network/config.ex
@@ -52,16 +52,18 @@ defmodule Nerves.Network.Config do
 
   def update(new, old) do
     {added, removed, modified} = changes(new, old)
-
     removed = Enum.map(removed, fn {k, _} -> {k, %{}} end)
     modified = added ++ modified
 
     Enum.each(modified, fn {iface, settings} ->
-      IFSupervisor.setup(iface, settings)
+      # TODO(Connor): Maybe we should define a behaviour for
+      # Config changes for each of the managers?
+      :ok = IFSupervisor.teardown(iface)
+      {:ok, _} = IFSupervisor.setup(iface, settings)
     end)
 
     Enum.each(removed, fn {iface, _settings} ->
-      IFSupervisor.teardown(iface)
+      :ok = IFSupervisor.teardown(iface)
     end)
 
     new


### PR DESCRIPTION
For example if you configure your config.exs as such:
```elixir
config :nerves_network, :default, [
  wlan0: []
]
```

then try to do something like:
```elixir
Nerves.Network.setup("wlan0", [key_mgmt: :"WPA-PSK", ssid: "AndroidAP", psk: "12345678"])
```

It will return `:ok` but nothing will happen.
The fix is on changes, `teardown(iface)` then `setup(iface,
new_settings)`

This fixes #49