### PR TITLE
Ignore ifadded events when down

### DIFF
--- a/lib/nerves_network/static_manager.ex
+++ b/lib/nerves_network/static_manager.ex
@@ -131,6 +131,8 @@ defmodule Nerves.Network.StaticManager do
     |> goto_context(:up)
   end
 
+  defp consume(:down, :ifadded, state), do: state
+
   defp consume(:down, :ifdown, state), do: state
 
   defp consume(:down, :ifremoved, state) do


### PR DESCRIPTION
The interface is already added, so these can be safely ignored.