### PR TITLE
Allow configuration of multiple networks via `Nerves.Network.setup/2`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: erlang
 
 sudo: required
-dist: trusty
+dist: xenial
 
 otp_release:
     - 21.0

--- a/lib/nerves_network.ex
+++ b/lib/nerves_network.ex
@@ -9,6 +9,13 @@ defmodule Nerves.Network do
 
       Nerves.Network.setup "wlan0", ssid: "myssid", key_mgmt: :"WPA-PSK", psk: "secretsecret"
 
+  To configure multiple wireless networks, nest a list of wireless
+  configurations under the `:networks` key:
+
+      Nerves.Network.setup "wlan0", networks: [
+        [ssid: "myssid", key_mgmt: :"WPA-PSK", psk: "secretsecret"],
+        [ssid: "myotherssid", key_mgmt: :"WPA-PSK", psk: "othersecret", priority: 10]]
+
   When you boot your Nerves image, Nerves.Network monitors for an interface
   called "wlan0" to be created. This occurs when you plug in a USB WiFi dongle.
   If you plug in more than one WiFi dongle, each one will be given a name like
@@ -26,10 +33,18 @@ defmodule Nerves.Network do
           | {:ipv4_subnet_mask, Types.ip_address()}
           | {:domain, String.t()}
           | {:nameservers, [Types.ip_address()]}
-          | {atom, any()}
+          | {:networks, [[wifi_settings]]}
+          | wifi_settings
 
   @typedoc "Keyword List settings to `setup/2`"
   @type setup_settings :: [setup_setting]
+
+  @typedoc "WiFi Settings"
+  @type wifi_settings ::
+          {:ssid, String.t()}
+          | {:key_mgmt, :"WPA-PSK" | :NONE}
+          | {:psk, String.t()}
+          | {:priority, non_neg_integer}
 
   @doc """
   Configure the specified interface. Settings contains one or more of the

--- a/lib/nerves_network.ex
+++ b/lib/nerves_network.ex
@@ -33,18 +33,18 @@ defmodule Nerves.Network do
           | {:ipv4_subnet_mask, Types.ip_address()}
           | {:domain, String.t()}
           | {:nameservers, [Types.ip_address()]}
-          | {:networks, [[wifi_settings]]}
-          | wifi_settings
+          | {:networks, [[wifi_settings()]]}
+          | wifi_settings()
 
   @typedoc "Keyword List settings to `setup/2`"
-  @type setup_settings :: [setup_setting]
+  @type setup_settings :: [setup_setting()]
 
   @typedoc "WiFi Settings"
   @type wifi_settings ::
           {:ssid, String.t()}
           | {:key_mgmt, :"WPA-PSK" | :NONE}
           | {:psk, String.t()}
-          | {:priority, non_neg_integer}
+          | {:priority, non_neg_integer()}
 
   @doc """
   Configure the specified interface. Settings contains one or more of the
@@ -61,7 +61,7 @@ defmodule Nerves.Network do
 
   See `t(#{__MODULE__}.setup_setting)` for more info.
   """
-  @spec setup(Types.ifname(), setup_settings) :: :ok
+  @spec setup(Types.ifname(), setup_settings()) :: :ok
   def setup(ifname, settings \\ []) do
     Logger.debug("#{__MODULE__} setup(#{ifname})")
     {:ok, {_new, _old}} = Nerves.Network.Config.put(ifname, settings)

--- a/lib/nerves_network/wifi_manager.ex
+++ b/lib/nerves_network/wifi_manager.ex
@@ -409,7 +409,7 @@ defmodule Nerves.Network.WiFiManager do
           :ok
 
         error ->
-          Logger.info(
+          Logger.error(
             "WiFiManager(#{state.ifname}, #{state.context}) wpa_supplicant add_network error: #{
               inspect(error)
             }"

--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule Nerves.Network.Mixfile do
     [
       {:system_registry, "~> 0.7"},
       {:nerves_network_interface, "~> 0.4.4"},
-      {:nerves_wpa_supplicant, "~> 0.3"},
+      {:nerves_wpa_supplicant, ">= 0.4.0"},
       {:elixir_make, "~> 0.4", runtime: false},
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 0.5.1", only: [:dev, :test], runtime: false}

--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule Nerves.Network.Mixfile do
     [
       {:system_registry, "~> 0.7"},
       {:nerves_network_interface, "~> 0.4.4"},
-      {:nerves_wpa_supplicant, ">= 0.4.0"},
+      {:nerves_wpa_supplicant, "~> 0.4"},
       {:elixir_make, "~> 0.4", runtime: false},
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 0.5.1", only: [:dev, :test], runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "nerves_network_interface": {:hex, :nerves_network_interface, "0.4.4", "200b1a84bc1a7fdeaf3a1e0e2d4e9b33e240b034e73f39372768d43f8690bae0", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
-  "nerves_wpa_supplicant": {:hex, :nerves_wpa_supplicant, "0.3.3", "91b8505c023e891561ac6c64b9955450aa67fb16b523b18db5eeb4b4bcf30dc7", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  "nerves_wpa_supplicant": {:hex, :nerves_wpa_supplicant, "0.4.0", "85e69d81e1b9e040d744706783142dc12a74fe3cba7ec69cfe7ba15df52e1e12", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},
   "system_registry": {:hex, :system_registry, "0.8.0", "09240347628b001433d18279a2759ef7237ba7361239890d8c599cca9a2fbbc2", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
I rebased @tmecklem 's change and updated it to work with the current version of Nerves Network.
I've tested two networks, with varying combinations of settings and it seems to work.

By nesting multiple wireless networks under the `:network` key, setup
will add and enable each network and then trigger WpaSupplicant to
scan and connect to the available network with the highest priority.

This maintains backwards compatibility with single wireless network
configuration.

