### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
-## v0.3.8-dev
-  * Enhancements
-    * Removed wifi credentials from Logger.
+## v0.4.0
+
+* Enhancements
+  * Removed WiFi credentials from Logger
+  * Support configuration of multiple networks. 
+    See [#72](https://github.com/nerves-project/nerves_network/issues/72)
 
 ## v0.3.7
   * Add typespecs for all the moving parts.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Nerves.Network.Mixfile do
   def project do
     [
       app: :nerves_network,
-      version: "0.3.8-dev",
+      version: "0.4.0",
       elixir: "~> 1.4",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
@@ -43,7 +43,6 @@ defmodule Nerves.Network.Mixfile do
         "Makefile",
         "docs/*.md"
       ],
-      maintainers: ["Frank Hunleth", "Justin Schneck", "Connor Rigby"],
       licenses: ["Apache-2.0"],
       links: %{"GitHub" => "https://github.com/nerves-project/nerves_network"}
     }


### PR DESCRIPTION
I decided to do 0.4.0 instead of 0.3.8 because the API has new options, but _are_ backwards compatible
