### PR TITLE
Refactor WiFi priority to allow independent ip settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,53 @@ config :nerves_network, :default,
 
 If you are using an older version (`< 0.3.0`) of `nerves_runtime` then you'll need to do some additional setup to load the correct kernel module for WiFi. See [this page](OLD_NERVES_RUNTIME.md) for more information.
 
+## WiFi Networking Priority
+
+If you have more than one possible network, and you would like to automatically
+connect the highest priority one you can:
+
+```elixir
+settings = [
+  networks: [
+    [ssid: "FirstPriority", psk: "superSecret", key_mgmt: :"WPA-PSK", priority: 100],
+    [ssid: "SettleForThisOne", psk: "StillSecret", key_mgmt: :"WPA-PSK", priority: 10],
+    [ssid: "ConnectIfThoseOtherOnesArentAvailable", key_mgmt: :NONE, priority: 0,
+      ipv4_address_method: :static,
+      ipv4_address: "10.0.0.2", ipv4_subnet_mask: "255.255.0.0",
+      domain: "mycompany.com", nameservers: ["8.8.8.8", "8.8.4.4"],
+    ]
+  ]
+]
+
+# Now you can either use `default` or runtime setup.
+
+## Default
+use Mix.Config
+config :nerves_network, default: [
+  wlan0: settings,
+  eth0: []
+]
+
+## Runtime
+Nerves.Network.setup("wlan0", settings)
+```
+
+## WiFi Network host mode
+WpaSupplicant supports WiFi host mode (`mode: 2`). This means it will create an 
+access point rather than connect to one. example settings for this:
+
+```elixir
+settings = [
+  networks: [
+    # Note the final `d` in `dhcpd`
+    # this will start `OneDHCPD` on the interface.
+    [ssid: "NervesAP", psk: "supersecret", key_mgmt: :"WPA-PSK", mode: 2,
+     ipv4_address_method: :dhcpd] 
+  ]
+]
+Nerves.Network.setup("wlan0", settings)
+```
+
 ## Scanning
 
 You can scan by running:

--- a/config/config.exs
+++ b/config/config.exs
@@ -8,6 +8,4 @@ config :nerves_network, :default,
     psk: System.get_env("NERVES_NETWORK_PSK"),
     key_mgmt: String.to_atom(key_mgmt)
   ],
-  eth0: [
-    ipv4_address_method: :dhcp
-  ]
+  eth0: []

--- a/lib/nerves_network.ex
+++ b/lib/nerves_network.ex
@@ -47,17 +47,23 @@ defmodule Nerves.Network do
           | {:priority, non_neg_integer()}
 
   @doc """
-  Configure the specified interface. Settings contains one or more of the
-  following:
+  Configure the specified interface. 
+    
+    ## Common settings
+    Settings contains one or more of the following IP address settings:
 
-    * `:ipv4_address_method` - `:dhcp`, `:static`, or `:linklocal`
+    * `:ipv4_address_method` - `:dhcp`, `:dhcpd`, `:static`, or `:linklocal`
     * `:ipv4_address` - e.g., "192.168.1.5" (specify when :ipv4_address_method = :static)
     * `:ipv4_subnet_mask` - e.g., "255.255.255.0" (specify when :ipv4_address_method = :static)
     * `:domain` - e.g., "mycompany.com" (specify when :ipv4_address_method = :static)
     * `:nameservers` - e.g., ["8.8.8.8", "8.8.4.4"] (specify when :ipv4_address_method = :static)
-    * `:ssid` - "My WiFi AP" (specify if this is a wireless interface)
-    * `:key_mgmt` - e.g., `:"WPA-PSK"` or `:NONE`
-    * `:psk` - e.g., "my-secret-wlan-key"
+
+    ## WiFi settings
+    * `networks` - a list of one or more network settings. Should contain
+      one or more of the following settings:
+      * `:ssid` - "My WiFi AP" (specify if this is a wireless interface)
+      * `:key_mgmt` - e.g., `:"WPA-PSK"` or `:NONE`
+      * `:psk` - e.g., "my-secret-wlan-key"
 
   See `t(#{__MODULE__}.setup_setting)` for more info.
   """

--- a/lib/nerves_network/types.ex
+++ b/lib/nerves_network/types.ex
@@ -15,4 +15,14 @@ defmodule Nerves.Network.Types do
   @type interface_context :: :removed | :retry_add | :down | :up
 
   @type udhcp_info :: %{ifname: ifname, nameservers: [ip_address], domain: String.t()}
+
+  @type ip_settings :: %{
+          optional(:ipv4_address_method) => String.t(),
+          optional(:ipv4_address) => String.t(),
+          optional(:ipv4_broadcast) => String.t(),
+          optional(:ipv4_subnet_mask) => String.t(),
+          optional(:ipv4_gateway) => String.t(),
+          optional(:domain) => String.t(),
+          optional(:nameservers) => String.t()
+        }
 end

--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,8 @@ defmodule Nerves.Network.Mixfile do
     [
       {:system_registry, "~> 0.7"},
       {:nerves_network_interface, "~> 0.4.4"},
-      {:nerves_wpa_supplicant, "~> 0.4"},
+      {:nerves_wpa_supplicant, "~> 0.5"},
+      {:one_dhcpd, "~> 0.2.0"},
       {:elixir_make, "~> 0.4", runtime: false},
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 0.5.1", only: [:dev, :test], runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,8 @@
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "nerves_network_interface": {:hex, :nerves_network_interface, "0.4.4", "200b1a84bc1a7fdeaf3a1e0e2d4e9b33e240b034e73f39372768d43f8690bae0", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
-  "nerves_wpa_supplicant": {:hex, :nerves_wpa_supplicant, "0.4.0", "85e69d81e1b9e040d744706783142dc12a74fe3cba7ec69cfe7ba15df52e1e12", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  "nerves_wpa_supplicant": {:git, "https://github.com/nerves-project/nerves_wpa_supplicant.git", "60f6d9abdbff81abe474f5086923180fa5f6f5bf", [branch: "notif-decode"]},
   "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},
+  "one_dhcpd": {:hex, :one_dhcpd, "0.2.0", "18eb8ce7101ad7b79e67f3d7ee7f648f42e02b8fa4c1cb3f24f403bf6860f81d", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
   "system_registry": {:hex, :system_registry, "0.8.0", "09240347628b001433d18279a2759ef7237ba7361239890d8c599cca9a2fbbc2", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
This PR requires https://github.com/nerves-project/nerves_wpa_supplicant/pull/19 before merging

This allows each network to have it's own ip address settings
in the WiFiManager module. This allows for a simple priority
system where a user can configure a primary ip, then fall back
to creating a hostap network if the network wasn't found or is
disconnected etc.