### PR TITLE
Ignore duplicate ifadded

### DIFF
--- a/lib/nerves_network/dhcp_manager.ex
+++ b/lib/nerves_network/dhcp_manager.ex
@@ -231,6 +231,7 @@ defmodule Nerves.Network.DHCPManager do
   end
 
   ## Context: :up
+  defp consume(:up, :ifadded, state), do: state
   defp consume(:up, :ifup, state), do: state
 
   defp consume(:up, :dhcp_retry, state) do


### PR DESCRIPTION
I'm not sure why I'm seeing this, but it's harmless, so this PR ignores the ifadded event when the interface is already up.