### PR TITLE
Enforce interface settings are keyword lists

### DIFF
--- a/lib/nerves_network/config.ex
+++ b/lib/nerves_network/config.ex
@@ -72,7 +72,7 @@ defmodule Nerves.Network.Config do
 
       # Don't match on teardown since it might not actually be up yet.
       IFSupervisor.teardown(iface)
-      {:ok, _} = IFSupervisor.setup(iface, settings)
+      {:ok, _} = IFSupervisor.setup(iface, Enum.into(settings, []))
     end)
 
     Enum.each(removed, fn {iface, _settings} ->


### PR DESCRIPTION
Values coming back from system registry are going to be maps but the main API for `Nerves.Network.setup` only allows keyword lists.