### PR TITLE
Build C code in _build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,28 @@
-# Variables to override
+# Makefile for building port binaries
 #
-# CC            C compiler. MUST be set if crosscompiling
+# Makefile targets:
+#
+# all/install   build and install the NIF
+# clean         clean build products and intermediates
+#
+# Variables to override:
+#
+# MIX_COMPILE_PATH path to the build's ebin directory
+#
+# CC            C compiler
 # CROSSCOMPILE	crosscompiler prefix, if any
-# CFLAGS        compiler flags for compiling all C files
-# LDFLAGS       linker flags for linking all binaries
-# ERL_LDFLAGS   additional linker flags for projects referencing Erlang libraries
+# CFLAGS	compiler flags for compiling all C files
+# LDFLAGS	linker flags for linking all binaries
+# ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
 # SUDO_ASKPASS  path to ssh-askpass when modifying ownership of udhcpc_wrapper
 # SUDO          path to SUDO. If you don't want the privileged parts to run, set to "true"
+
+ifeq ($(MIX_COMPILE_PATH),)
+	$(error MIX_COMPILE_PATH should be set by elixir_make!)
+endif
+
+PREFIX = $(MIX_COMPILE_PATH)/../priv
+BUILD  = $(MIX_COMPILE_PATH)/../obj
 
 # Check that we're on a supported build platform
 ifeq ($(CROSSCOMPILE),)
@@ -18,10 +34,10 @@ ifeq ($(CROSSCOMPILE),)
         $(warning this should be done automatically.)
         $(warning .)
         $(warning Skipping C compilation unless targets explicitly passed to make.)
-	DEFAULT_TARGETS = priv
+	DEFAULT_TARGETS = $(PREFIX)
     endif
 endif
-DEFAULT_TARGETS ?= priv priv/udhcpc_wrapper
+DEFAULT_TARGETS ?= $(PREFIX) $(PREFIX)/udhcpc_wrapper
 
 LDFLAGS +=
 CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter
@@ -36,20 +52,28 @@ else
 SUDO ?= true
 endif
 
-.PHONY: all clean
+calling_from_make:
+	mix compile
 
-all: $(DEFAULT_TARGETS)
+all: install
 
-%.o: %.c
+install: $(BUILD) $(DEFAULT_TARGETS)
+
+$(BUILD)/%.o: src/%.c
 	$(CC) -c $(CFLAGS) -o $@ $<
 
-priv:
-	mkdir -p priv
-
-priv/udhcpc_wrapper: src/udhcpc_wrapper.o
+$(PREFIX)/udhcpc_wrapper: $(BUILD)/udhcpc_wrapper.o
 	$(CC) $^ $(ERL_LDFLAGS) $(LDFLAGS) -o $@
 	# setuid root udhcpc_wrapper so that it can call udhcpc
 	SUDO_ASKPASS=$(SUDO_ASKPASS) $(SUDO) -- sh -c 'chown root:root $@; chmod +s $@'
 
+$(PREFIX):
+	mkdir -p $@
+
+$(BUILD):
+	mkdir -p $@
+
 clean:
-	rm -f priv/udhcpc_wrapper src/*.o
+	$(RM) -f $(PREFIX)/udhcpc_wrapper $(BUILD)/*.o
+
+.PHONY: all clean calling_from_make install

--- a/mix.exs
+++ b/mix.exs
@@ -6,9 +6,10 @@ defmodule Nerves.Network.Mixfile do
       app: :nerves_network,
       version: "0.5.4",
       elixir: "~> 1.4",
-      build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      compilers: [:elixir_make] ++ Mix.compilers(),
+      build_embedded: true,
+      compilers: [:elixir_make | Mix.compilers()],
+      make_targets: ["all"],
       make_clean: ["clean"],
       deps: deps(),
       docs: [extras: ["README.md"] ++ Path.wildcard("docs/*.md")],
@@ -54,7 +55,7 @@ defmodule Nerves.Network.Mixfile do
       {:nerves_network_interface, "~> 0.4.4"},
       {:nerves_wpa_supplicant, "~> 0.5"},
       {:one_dhcpd, "~> 0.2.0"},
-      {:elixir_make, "~> 0.4", runtime: false},
+      {:elixir_make, "~> 0.5", runtime: false},
       {:ex_doc, "~> 0.19", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 0.5.1", only: [:dev, :test], runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
-  "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
+  "elixir_make": {:hex, :elixir_make, "0.5.1", "cee27c69bddcd6e333a24f2313786d1c9a970c49fcf700ecf1f7246f3a210f39", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
This pulls in updates from other Nerves projects to move the C build
products under the _build directory so that its possible to build for
multiple targets without cleaning first.